### PR TITLE
Version 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,25 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0] - 2020-03-04
+
 ### Added
 
-- Language code pt, zh, zh-Hans, zh-Hant
-- Dark mode
-- Megamenu
-- Table of content
-- New icon set based on Remix Icon
+- gulp, js: individual component js files
+- gulp, js: split wiki js into chameleon-wiki.js
+- gulp, css: split wiki js into chameleon-wiki.css
+- icon: _Remix Icon_ with openSUSE additional icons
+- css: dark mode
+- css,js: megamenu component
+- css,js: table of content (toc) component
+- l10n: more translations and language codes support
+- wiki: heading anchors and edit buttons with icons
 
 ### Chagned
 
-- Update to Bootstrap 4.4.1
-- Use Source Sans Pro and Source Code Pro fonts
-- Remove border-radius
-- Colors follow [openSUSE Design System](https://opensuse.eosdesignsystem.com/colors)
-- Alert component style
+- npm: update bootstrap to 4.4.1
+- gulp: don't minify/uglify css and js, so the code is more human readable
+- font: use _Source Sans Pro_ and _Source Code Pro_ fonts
+- css: disable border-radius
+- css: colors follow [openSUSE Design System](https://opensuse.eosdesignsystem.com/colors)
+- css: alert
+- css: dropdown
 
 ### Removed
 
-- **BREAKING CHANGE**: Typicons (use RemixIcons instead)
+- icon: _Typicons_. **BREAKING CHANGE**: use _Remix Icon_ instead
+- font: removed _Open Sans_ fonts. Use _Source Sans Pro_ instead
 
 ## [1.3.0] - 2019-03-02
 
@@ -90,7 +99,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Brazilian Portuguese translation from openSUSE contributors.
 - Detailed README for using it in other openSUSE projects.
 
-[unreleased]: https://github.com/openSUSE/chameleon/compare/v1.3.0...HEAD
+[unreleased]: https://github.com/openSUSE/chameleon/compare/v2.0.0...HEAD
+[2.0.0]: https://github.com/openSUSE/chameleon/compare/v1.3.0...v2.0.0
 [1.3.0]: https://github.com/openSUSE/chameleon/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/openSUSE/chameleon/compare/v1.1.1...v1.2.0
 [1.1.1]: https://github.com/openSUSE/chameleon/compare/v1.1.0...v1.1.1

--- a/GET_STARTED.md
+++ b/GET_STARTED.md
@@ -9,12 +9,12 @@ webpage loading speed. This is the most recommended way to use Chameleon.
 <!-- Chameleon Style -->
 <link
   rel="stylesheet"
-  href="https://static.opensuse.org/chameleon/dist/css/chameleon.css"
+  href="https://static.opensuse.org/chameleon-2.0/dist/css/chameleon.css"
 />
 
 <!-- Chameleon Script Bundled with jQuery and Bootstrap -->
 <script
-  src="https://static.opensuse.org/chameleon/dist/js/chameleon.js"
+  src="https://static.opensuse.org/chameleon-2.0/dist/js/chameleon.js"
   defer
 ></script>
 ```
@@ -24,7 +24,7 @@ If the website (WordPress, MediaWiki, etc.) already provides jQuery:
 ```html
 <!-- Chameleon Script Bundled with Bootstrap -->
 <script
-  src="https://static.opensuse.org/chameleon/dist/js/chameleon-no-jquery.js"
+  src="https://static.opensuse.org/chameleon-2.0/dist/js/chameleon-no-jquery.js"
   defer
 ></script>
 ```
@@ -34,7 +34,7 @@ If the website (for Weblate, etc.) already provides jQuery and Bootstrap 4:
 ```html
 <!-- Chameleon Script -->
 <script
-  src="https://static.opensuse.org/chameleon/dist/js/chameleon-no-bootstrap.js"
+  src="https://static.opensuse.org/chameleon-2.0/dist/js/chameleon-no-bootstrap.js"
   defer
 ></script>
 ```

--- a/changelog.html
+++ b/changelog.html
@@ -2,26 +2,34 @@
 <p>All notable changes to this project will be documented in this file.</p>
 <p>The format is based on <a href="https://keepachangelog.com/en/1.0.0/">Keep a Changelog</a>,
 and this project adheres to <a href="https://semver.org/spec/v2.0.0.html">Semantic Versioning</a>.</p>
-<h2><a href="https://github.com/openSUSE/chameleon/compare/v1.3.0...HEAD">Unreleased</a></h2>
+<h2><a href="https://github.com/openSUSE/chameleon/compare/v2.0.0...HEAD">Unreleased</a></h2>
+<h2><a href="https://github.com/openSUSE/chameleon/compare/v1.3.0...v2.0.0">2.0.0</a> - 2020-03-04</h2>
 <h3>Added</h3>
 <ul>
-<li>Language code pt, zh, zh-Hans, zh-Hant</li>
-<li>Dark mode</li>
-<li>Megamenu</li>
-<li>Table of content</li>
-<li>New icon set based on Remix Icon</li>
+<li>gulp, js: individual component js files</li>
+<li>gulp, js: split wiki js into chameleon-wiki.js</li>
+<li>gulp, css: split wiki js into chameleon-wiki.css</li>
+<li>icon: <em>Remix Icon</em> with openSUSE additional icons</li>
+<li>css: dark mode</li>
+<li>css,js: megamenu component</li>
+<li>css,js: table of content (toc) component</li>
+<li>l10n: more translations and language codes support</li>
+<li>wiki: heading anchors and edit buttons with icons</li>
 </ul>
 <h3>Chagned</h3>
 <ul>
-<li>Update to Bootstrap 4.4.1</li>
-<li>Use Source Sans Pro and Source Code Pro fonts</li>
-<li>Remove border-radius</li>
-<li>Colors follow <a href="https://opensuse.eosdesignsystem.com/colors">openSUSE Design System</a></li>
-<li>Alert component style</li>
+<li>npm: update bootstrap to 4.4.1</li>
+<li>gulp: don't minify/uglify css and js, so the code is more human readable</li>
+<li>font: use <em>Source Sans Pro</em> and <em>Source Code Pro</em> fonts</li>
+<li>css: disable border-radius</li>
+<li>css: colors follow <a href="https://opensuse.eosdesignsystem.com/colors">openSUSE Design System</a></li>
+<li>css: alert</li>
+<li>css: dropdown</li>
 </ul>
 <h3>Removed</h3>
 <ul>
-<li><strong>BREAKING CHANGE</strong>: Typicons (use RemixIcons instead)</li>
+<li>icon: <em>Typicons</em>. <strong>BREAKING CHANGE</strong>: use <em>Remix Icon</em> instead</li>
+<li>font: removed <em>Open Sans</em> fonts. Use <em>Source Sans Pro</em> instead</li>
 </ul>
 <h2><a href="https://github.com/openSUSE/chameleon/compare/v1.2.0...v1.3.0">1.3.0</a> - 2019-03-02</h2>
 <h3>Added</h3>

--- a/get-started.html
+++ b/get-started.html
@@ -5,26 +5,26 @@ webpage loading speed. This is the most recommended way to use Chameleon.</p>
 <pre><code class="language-html">&lt;!-- Chameleon Style --&gt;
 &lt;link
   rel=&quot;stylesheet&quot;
-  href=&quot;https://static.opensuse.org/chameleon/dist/css/chameleon.css&quot;
+  href=&quot;https://static.opensuse.org/chameleon-2.0/dist/css/chameleon.css&quot;
 /&gt;
 
 &lt;!-- Chameleon Script Bundled with jQuery and Bootstrap --&gt;
 &lt;script
-  src=&quot;https://static.opensuse.org/chameleon/dist/js/chameleon.js&quot;
+  src=&quot;https://static.opensuse.org/chameleon-2.0/dist/js/chameleon.js&quot;
   defer
 &gt;&lt;/script&gt;
 </code></pre>
 <p>If the website (WordPress, MediaWiki, etc.) already provides jQuery:</p>
 <pre><code class="language-html">&lt;!-- Chameleon Script Bundled with Bootstrap --&gt;
 &lt;script
-  src=&quot;https://static.opensuse.org/chameleon/dist/js/chameleon-no-jquery.js&quot;
+  src=&quot;https://static.opensuse.org/chameleon-2.0/dist/js/chameleon-no-jquery.js&quot;
   defer
 &gt;&lt;/script&gt;
 </code></pre>
 <p>If the website (for Weblate, etc.) already provides jQuery and Bootstrap 4:</p>
 <pre><code class="language-html">&lt;!-- Chameleon Script --&gt;
 &lt;script
-  src=&quot;https://static.opensuse.org/chameleon/dist/js/chameleon-no-bootstrap.js&quot;
+  src=&quot;https://static.opensuse.org/chameleon-2.0/dist/js/chameleon-no-bootstrap.js&quot;
   defer
 &gt;&lt;/script&gt;
 </code></pre>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensuse/chameleon",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "description": "Vivid UI theme for openSUSE websites",
   "main": "dist/js/chameleon.js",
   "sass": "src/sass/chameleon.scss",


### PR DESCRIPTION
### Added

- gulp, js: individual component js files
- gulp, js: split wiki js into chameleon-wiki.js
- gulp, css: split wiki js into chameleon-wiki.css
- icon: _Remix Icon_ with openSUSE additional icons
- css: dark mode
- css,js: megamenu component
- css,js: table of content (toc) component
- l10n: more translations and language codes support
- wiki: heading anchors and edit buttons with icons

### Chagned

- npm: update bootstrap to 4.4.1
- gulp: don't minify/uglify css and js, so the code is more human readable
- font: use _Source Sans Pro_ and _Source Code Pro_ fonts
- css: disable border-radius
- css: colors follow [openSUSE Design System](https://opensuse.eosdesignsystem.com/colors)
- css: alert
- css: dropdown

### Removed

- icon: _Typicons_. **BREAKING CHANGE**: use _Remix Icon_ instead
- font: removed _Open Sans_ fonts. Use _Source Sans Pro_ instead